### PR TITLE
Use feature cfg outside macro

### DIFF
--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -1,0 +1,57 @@
+use std::sync::Once;
+
+#[cfg(not(feature="nightly"))]
+use std::mem::transmute;
+#[cfg(feature="nightly")]
+use std::cell::UnsafeCell;
+#[cfg(feature="nightly")]
+use std::sync::ONCE_INIT;
+
+#[cfg(feature="nightly")]
+pub struct Lazy<T: Sync>(UnsafeCell<Option<T>>, Once);
+
+#[cfg(not(feature="nightly"))]
+pub struct Lazy<T: Sync>(pub *const T, pub Once);
+
+#[cfg(feature="nightly")]
+impl<T: Sync> Lazy<T> {
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Lazy(UnsafeCell::new(None), ONCE_INIT)
+    }
+
+    #[inline(always)]
+    pub fn get<F>(&'static self, f: F) -> &T
+        where F: FnOnce() -> T
+    {
+        unsafe {
+            self.1.call_once(|| {
+                *self.0.get() = Some(f());
+            });
+
+            match *self.0.get() {
+                Some(ref x) => x,
+                None => ::std::intrinsics::unreachable(),
+            }
+        }
+    }
+}
+
+#[cfg(not(feature="nightly"))]
+impl<T: Sync> Lazy<T> {
+    #[inline(always)]
+    pub fn get<F>(&'static mut self, f: F) -> &T
+        where F: FnOnce() -> T
+    {
+        unsafe {
+            let r = &mut self.0;
+            self.1.call_once(|| {
+                *r = transmute(Box::new(f()));
+            });
+
+            &*self.0
+        }
+    }
+}
+
+unsafe impl<T: Sync> Sync for Lazy<T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@ trait.
 
 Using the macro:
 
-```ignore
+```
+# #![cfg_attr(feature="nightly", feature(const_fn, core_intrinsics))]
 #[macro_use]
 extern crate lazy_static;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ trait.
 
 Using the macro:
 
-```rust
+```ignore
 #[macro_use]
 extern crate lazy_static;
 
@@ -71,6 +71,25 @@ The `Deref` implementation uses a hidden static variable that is guarded by a at
 #![cfg_attr(feature="nightly", feature(const_fn, core_intrinsics))]
 #![crate_type = "dylib"]
 
+pub mod lazy;
+
+#[cfg(feature="nightly")]
+#[macro_export]
+macro_rules! lazy_create {
+    ($T:ty) => {
+        static LAZY: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy::new();
+    }
+}
+
+#[cfg(not(feature="nightly"))]
+#[macro_export]
+macro_rules! lazy_create {
+    ($T:ty) => {
+        use std::sync::ONCE_INIT;
+        static mut LAZY: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy(0 as *const $T, ONCE_INIT);
+    }
+}
+
 #[macro_export]
 macro_rules! lazy_static {
     ($(#[$attr:meta])* static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
@@ -84,51 +103,15 @@ macro_rules! lazy_static {
         impl ::std::ops::Deref for $N {
             type Target = $T;
             fn deref<'a>(&'a self) -> &'a $T {
-                #[inline(always)]
-                fn __static_ref_initialize() -> $T { $e }
-
                 unsafe {
-                    use std::sync::{Once, ONCE_INIT};
-
                     #[inline(always)]
-                    fn require_sync<T: Sync>(_: &T) { }
+                    fn __static_ref_initialize() -> $T { $e }
 
-                    #[inline(always)]
-                    #[cfg(feature="nightly")]
                     unsafe fn __stability() -> &'static $T {
-                        use std::cell::UnsafeCell;
-
-                        struct SyncCell(UnsafeCell<Option<$T>>);
-                        unsafe impl Sync for SyncCell {}
-
-                        static DATA: SyncCell = SyncCell(UnsafeCell::new(None));
-                        static ONCE: Once = ONCE_INIT;
-                        ONCE.call_once(|| {
-                            *DATA.0.get() = Some(__static_ref_initialize());
-                        });
-                        match *DATA.0.get() {
-                            Some(ref x) => x,
-                            None => ::std::intrinsics::unreachable(),
-                        }
+                        lazy_create!($T);
+                        LAZY.get(__static_ref_initialize)
                     }
-
-                    #[inline(always)]
-                    #[cfg(not(feature="nightly"))]
-                    unsafe fn __stability() -> &'static $T {
-                        use std::mem::transmute;
-
-                        static mut DATA: *const $T = 0 as *const $T;
-                        static mut ONCE: Once = ONCE_INIT;
-                        ONCE.call_once(|| {
-                            DATA = transmute::<Box<$T>, *const $T>(
-                                Box::new(__static_ref_initialize()));
-                        });
-                        &*DATA
-                    }
-
-                    let static_ref = __stability();
-                    require_sync(static_ref);
-                    static_ref
+                    __stability()
                 }
             }
         }


### PR DESCRIPTION
cfg(feature="nightly") was being evaluated within the crate using the
lazy_static! macro. Instead we generate different macros depending on
the cfg.