### PR TITLE
add allow_internal_unstable and remove core_intrinsics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,11 @@ The `Deref` implementation uses a hidden static variable that is guarded by a at
 
 */
 
-#![cfg_attr(feature="nightly", feature(const_fn, core_intrinsics))]
+#![cfg_attr(feature="nightly", feature(const_fn, allow_internal_unstable))]
 #![crate_type = "dylib"]
 
 #[macro_export]
+#[cfg_attr(feature="nightly", allow_internal_unstable)]
 macro_rules! lazy_static {
     ($(#[$attr:meta])* static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
         lazy_static!(PRIV, $(#[$attr])* static ref $N : $T = $e; $($t)*);


### PR DESCRIPTION
This patch annotates the macro with the unstable `allow_internal_unstable` attribute (gated behind the extant "nightly" feature) so that dependents don't have to declare `feature(const_fn)`. Also, `feature(core_intrinsics)` seemed unused so I removed it.