### PR TITLE
fix tests on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ trait.
 Using the macro:
 
 ```rust
+# #![cfg_attr(feature="nightly", feature(const_fn, core_intrinsics))]
 #[macro_use]
 extern crate lazy_static;
 
@@ -68,7 +69,6 @@ The `Deref` implementation uses a hidden static variable that is guarded by a at
 
 */
 
-#![cfg_attr(feature="nightly", feature(const_fn, core_intrinsics))]
 #![crate_type = "dylib"]
 
 #[macro_export]


### PR DESCRIPTION
The doctest was failing because of the missing feature attribute. And putting feature attributes in the root of a macro-only crate is pointless.