### PR TITLE
Use the full path for the `Box` type.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ macro_rules! lazy_static {
                     #[cfg(not(feature="nightly"))]
                     unsafe fn __stability() -> &'static $T {
                         use std::mem::transmute;
+                        use std::boxed::Box;
 
                         static mut DATA: *const $T = 0 as *const $T;
                         static mut ONCE: Once = ONCE_INIT;


### PR DESCRIPTION
Here's an example when it causes a problem: https://github.com/servo/servo/pull/10488#issue-147047204