### PR TITLE
Stabilize API and rename to lazy-static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "lazy_static"
-version = "0.2.1"
+name = "lazy-static"
+version = "1.0.0"
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT"
 


### PR DESCRIPTION
I'm opening this issue mostly to start a discussion about the stability of this package.

It looks to me that the external API of lazy-static hasn't changed for a while. Is it possible to release this as a 1.0.0? If not, what is required for that to happen?

Per #45 I've also taken the liberty to rename the crate to "lazy-static". I don't think this is an issue since other crates eventually will have to change their dependency (as depending on pre-v1 should only be a temporary solution).
