### PR TITLE
Switch lazy_static over to mutable statics instead of UnsafeCell on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["macro", "lazy", "static"]
 categories = [ "no-std", "rust-patterns", "memory-management" ]
 
 [dependencies.spin]
-version = "0.4"
+version = "0.4.6"
 optional = true
 
 [dependencies.compiletest_rs]

--- a/src/core_lazy.rs
+++ b/src/core_lazy.rs
@@ -26,8 +26,6 @@ impl<T: Sync> Lazy<T> {
 }
 
 #[macro_export]
-#[allow_internal_unstable]
-#[doc(hidden)]
 macro_rules! __lazy_static_create {
     ($NAME:ident, $T:ty) => {
         static $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy::new();

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -9,6 +9,7 @@ extern crate std;
 
 use self::std::prelude::v1::*;
 use self::std::sync::Once;
+pub use self::std::sync::ONCE_INIT;
 
 pub struct Lazy<T: Sync>(pub *const T, pub Once);
 
@@ -31,10 +32,8 @@ impl<T: Sync> Lazy<T> {
 unsafe impl<T: Sync> Sync for Lazy<T> {}
 
 #[macro_export]
-#[doc(hidden)]
 macro_rules! __lazy_static_create {
     ($NAME:ident, $T:ty) => {
-        use std::sync::ONCE_INIT;
-        static mut $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy(0 as *const $T, ONCE_INIT);
+        static mut $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy(0 as *const $T, $crate::lazy::ONCE_INIT);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,10 @@ The `Deref` implementation uses a hidden static variable that is guarded by a at
 
 */
 
-#![cfg_attr(feature="nightly", feature(const_fn, allow_internal_unstable, core_intrinsics, const_unsafe_cell_new))]
+#![cfg_attr(feature="spin_no_std", feature(const_fn))]
+#![cfg_attr(feature="nightly", feature(unreachable))]
 
-#![doc(html_root_url = "https://docs.rs/lazy_static/0.2.8")]
+#![doc(html_root_url = "https://docs.rs/lazy_static/0.2.10")]
 #![no_std]
 
 #[cfg(not(feature="nightly"))]
@@ -113,7 +114,6 @@ pub mod lazy;
 pub use core::ops::Deref as __Deref;
 
 #[macro_export]
-#[cfg_attr(feature="nightly", allow_internal_unstable)]
 #[doc(hidden)]
 macro_rules! __lazy_static_internal {
     // optional visibility restrictions are wrapped in `()` to allow for
@@ -161,7 +161,6 @@ macro_rules! __lazy_static_internal {
 }
 
 #[macro_export]
-#[cfg_attr(feature="nightly", allow_internal_unstable)]
 macro_rules! lazy_static {
     ($(#[$attr:meta])* static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
         // use `()` to explicitly forward the information about private items

--- a/src/nightly_lazy.rs
+++ b/src/nightly_lazy.rs
@@ -8,16 +8,12 @@
 extern crate std;
 
 use self::std::prelude::v1::*;
-use self::std::sync::{Once, ONCE_INIT};
+use self::std::sync::Once;
+pub use self::std::sync::ONCE_INIT;
 
-pub struct Lazy<T: Sync>(Option<T>, Once);
+pub struct Lazy<T: Sync>(pub Option<T>, pub Once);
 
 impl<T: Sync> Lazy<T> {
-    #[inline(always)]
-    pub const fn new() -> Self {
-        Lazy(None, ONCE_INIT)
-    }
-
     #[inline(always)]
     pub fn get<F>(&'static mut self, f: F) -> &T
         where F: FnOnce() -> T
@@ -31,7 +27,7 @@ impl<T: Sync> Lazy<T> {
         unsafe {
             match self.0 {
                 Some(ref x) => x,
-                None => std::intrinsics::unreachable(),
+                None => std::mem::unreachable(),
             }
         }
     }
@@ -40,10 +36,8 @@ impl<T: Sync> Lazy<T> {
 unsafe impl<T: Sync> Sync for Lazy<T> {}
 
 #[macro_export]
-#[allow_internal_unstable]
-#[doc(hidden)]
 macro_rules! __lazy_static_create {
     ($NAME:ident, $T:ty) => {
-        static mut $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy::new();
+        static mut $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy(None, $crate::lazy::ONCE_INIT);
     }
 }

--- a/src/nightly_lazy.rs
+++ b/src/nightly_lazy.rs
@@ -8,27 +8,28 @@
 extern crate std;
 
 use self::std::prelude::v1::*;
-use self::std::cell::UnsafeCell;
 use self::std::sync::{Once, ONCE_INIT};
 
-pub struct Lazy<T: Sync>(UnsafeCell<Option<T>>, Once);
+pub struct Lazy<T: Sync>(Option<T>, Once);
 
 impl<T: Sync> Lazy<T> {
     #[inline(always)]
     pub const fn new() -> Self {
-        Lazy(UnsafeCell::new(None), ONCE_INIT)
+        Lazy(None, ONCE_INIT)
     }
 
     #[inline(always)]
-    pub fn get<F>(&'static self, f: F) -> &T
+    pub fn get<F>(&'static mut self, f: F) -> &T
         where F: FnOnce() -> T
     {
-        unsafe {
+        {
+            let r = &mut self.0;
             self.1.call_once(|| {
-                *self.0.get() = Some(f());
+                *r = Some(f());
             });
-
-            match *self.0.get() {
+        }
+        unsafe {
+            match self.0 {
                 Some(ref x) => x,
                 None => std::intrinsics::unreachable(),
             }
@@ -43,6 +44,6 @@ unsafe impl<T: Sync> Sync for Lazy<T> {}
 #[doc(hidden)]
 macro_rules! __lazy_static_create {
     ($NAME:ident, $T:ty) => {
-        static $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy::new();
+        static mut $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy::new();
     }
 }

--- a/tests/compile-fail/static_is_sized.rs
+++ b/tests/compile-fail/static_is_sized.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate lazy_static;
+
+lazy_static! {
+    pub static ref FOO: str = panic!();
+}
+//^ ERROR `str` does not have a constant size known at compile-time
+
+fn main() {
+}

--- a/tests/compile-fail/static_is_sized.rs
+++ b/tests/compile-fail/static_is_sized.rs
@@ -1,10 +1,11 @@
+// error-pattern:the trait bound `str: std::marker::Sized` is not satisfied
 #[macro_use]
 extern crate lazy_static;
 
 lazy_static! {
     pub static ref FOO: str = panic!();
 }
-//^ ERROR `str` does not have a constant size known at compile-time
+
 
 fn main() {
 }


### PR DESCRIPTION
https://github.com/rust-lang/rfcs/pull/1440 got merged, so we can now get rid of the UnsafeCell in favor of directly having a drop type in a mutable static.

However, since the current `UnsafeCell` impl got also legitimized by the RFC, the current plan is to __not__ merge this PR until either the `drop_types_in_const` feature gets stabilized, or is at least old enough to not require the most current version of the compiler.