### PR TITLE
Use std::ptr::null() instead of `0 as *const _`

### DIFF
--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -27,7 +27,8 @@ unsafe impl<T: Sync> Sync for Lazy<T> {}
 #[doc(hidden)]
 macro_rules! __lazy_static_create {
     ($NAME:ident, $T:ty) => {
+        use std::ptr::null;
         use std::sync::ONCE_INIT;
-        static mut $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy(0 as *const $T, ONCE_INIT);
+        static mut $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy(null::<$T>(), ONCE_INIT);
     }
 }


### PR DESCRIPTION
This is mostly a cosmetic change, but it gets rid of clippy warnings in downstream code, e.g.

```rust
    |   lazy_static! {
    |  _^ starting here...
    ...
    | | }
    | |_^ ...ending here
    |
    = note: #[warn(zero_ptr)] on by default
    = note: this error originates in a macro outside of the current crate

warning: `0 as *const _` detected. Consider using `ptr::null()`
```