### PR TITLE
Add categories to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/lazy_static"
 
 repository = "https://github.com/rust-lang-nursery/lazy-static.rs"
 keywords = ["macro", "lazy", "static"]
+categories = [ "no-std", "rust-patterns" ]
 
 [dependencies.spin]
 version = "0.4"


### PR DESCRIPTION
Fixes #66 

These were the only two categories that I saw that made sense to me; maybe "memory_management", but that felt like a stretch.