### PR TITLE
Fix appveyor builds for stable channel

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,12 @@
 environment:
   global:
     PROJECT_NAME: lazy_static
+    # When this was added there were revocation check failures when using the
+    # libcurl backend as libcurl checks by default, but rustup doesn't provide the
+    # switch to turn this off. Switch to Hyper which looks to not check for
+    # revocation by default like libcurl does.
+    RUSTUP_USE_REQWEST: 1
+    CARGO_HTTP_CHECK_REVOKE: false
   matrix:
     # Stable channel
     - TARGET: i686-pc-windows-gnu
@@ -33,12 +39,9 @@ environment:
 # Install Rust and Cargo
 # (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/channel-rust-stable"
-  - ps: $env:RUST_VERSION = Get-Content channel-rust-stable | select -first 1 | %{$_.split('-')[1]}
-  - if NOT "%CHANNEL%" == "stable" set RUST_VERSION=%CHANNEL%
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_VERSION}-${env:TARGET}.exe"
-  - rust-%RUST_VERSION%-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
-  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init.exe -y --default-host %TARGET%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - if "%TARGET%" == "i686-pc-windows-gnu" set PATH=%PATH%;C:\msys64\mingw32\bin
   - if "%TARGET%" == "x86_64-pc-windows-gnu" set PATH=%PATH%;C:\msys64\mingw64\bin
   - rustc -V
@@ -47,5 +50,5 @@ install:
 build: false
 
 test_script:
-  - cargo build --verbose
-  - cargo test
+  - cargo build --verbose --target %TARGET%
+  - cargo test --target %TARGET%


### PR DESCRIPTION
This is an update of `appveyor.yml` based on the https://github.com/rust-lang/libc/blob/master/appveyor.yml file.