### PR TITLE
Add support for compiler tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ script:
   travis-cargo --only nightly build -- --features spin_no_std &&
   travis-cargo --only nightly test -- --features spin_no_std &&
   travis-cargo --only nightly bench -- --features spin_no_std &&
+  travis-cargo --only nightly clean &&
+  travis-cargo --only nightly build -- --features compiletest &&
+  travis-cargo --only nightly test -- --features compiletest &&
+  travis-cargo --only nightly clean &&
   travis-cargo --only stable doc
 after_success:
 - travis-cargo --only stable doc-upload

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,14 @@ categories = [ "no-std", "rust-patterns" ]
 version = "0.4"
 optional = true
 
+[dependencies.compiletest_rs]
+version = "0.3"
+optional = true
+
 [features]
 nightly = []
 spin_no_std = ["nightly", "spin"]
+compiletest = ["compiletest_rs"]
 
 [badges]
 appveyor = { repository = "rust-lang-nursery/lazy-static.rs" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ environment:
 # (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)
 install:
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init.exe -y --default-host %TARGET%
+  - rustup-init.exe -y --default-toolchain %CHANNEL% --default-host %TARGET%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - if "%TARGET%" == "i686-pc-windows-gnu" set PATH=%PATH%;C:\msys64\mingw32\bin
   - if "%TARGET%" == "x86_64-pc-windows-gnu" set PATH=%PATH%;C:\msys64\mingw64\bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,5 +50,10 @@ install:
 build: false
 
 test_script:
-  - cargo build --verbose --target %TARGET%
-  - cargo test --target %TARGET%
+  - cargo build --verbose
+  - cargo test
+  - if [%CHANNEL%]==[nightly] (
+      cargo clean &&
+      cargo build --verbose --features "compiletest" &&
+      cargo test --features "compiletest"
+    )

--- a/tests/compile-fail/README.md
+++ b/tests/compile-fail/README.md
@@ -1,0 +1,22 @@
+This directory contains snippets of code that should yield a
+warning/note/help/error at compilation. Syntax of annotations is described in
+[rust documentation](https://github.com/rust-lang/rust/blob/master/src/test/COMPILER_TESTS.md).
+For more information check out [`compiletest` crate](https://github.com/laumann/compiletest-rs).
+
+To run compile tests issue `cargo +nightly --test --features compiletest`.
+
+## Notes on working with `compiletest` crate
+
+* Currently code that is inside macro should not be annotated, as `compiletest`
+    crate cannot deal with the fact that macro invocations effectively changes
+    line numbering. To prevent this add a `// error-pattern:<your error message here>`
+    on the top of the file and make sure that you set `deny` lint level
+    if you want to test compiler message different than error.
+* `compiletest` crate by default sets `allow(dead_code)` lint level so make sure
+    that you change it to something suiting your needs even if the warning is
+    issued prior to any macro invocation.
+* If you get a message `error: 0 unexpected errors found, 1 expected errors not found`
+  despite the fact that some error was bound to occur don't worry - it's a known
+  issue in the `compiletest` crate and your error was probably not registered -
+  make sure that your annotations are correct and that you are setting correct
+  lint levels.

--- a/tests/compile-fail/static_never_used.rs
+++ b/tests/compile-fail/static_never_used.rs
@@ -1,0 +1,10 @@
+// error-pattern:static item is never used: `UNUSED`
+#![deny(dead_code)]
+#[macro_use]
+extern crate lazy_static;
+
+lazy_static! {
+    static ref UNUSED: () = ();
+}
+
+fn main() { }

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -1,0 +1,18 @@
+#![cfg(feature="compiletest")]
+extern crate compiletest_rs as compiletest;
+
+fn run_mode(mode: &'static str) {
+    let mut config = compiletest::Config::default();
+    config.mode = mode.parse().expect("Invalid mode");
+    config.src_base = ["tests", mode].iter().collect();
+    config.target_rustcflags = Some("-L target/debug/ -L target/debug/deps/".to_owned());
+
+    config.verbose = true;
+
+    compiletest::run_tests(&config);
+}
+
+#[test]
+fn compile_test() {
+    run_mode("compile-fail");
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -27,10 +27,6 @@ lazy_static! {
     static ref UNSAFE: u32 = unsafe {
         std::mem::transmute::<i32, u32>(-1)
     };
-
-    // This *should* triggger warn(dead_code) by design.
-    static ref UNUSED: () = ();
-
 }
 
 lazy_static! {


### PR DESCRIPTION
This is an initial version of compiler tests. So far it should work on travis, appveyor is a bit harder to achieve, because there's no simple way to add testing with specified features only on nightly. Please don't merge yet, because I want to at least try to make them run on appveyor as well.

Moreover due to the design of `compiletest` crate and its implementation details there isn't any clear way to annotate warnings/errors in lines that are being expanded by the macro, but rather we are forced to use `error-pattern` general mechanism. I will document that in code later on, just wanted to highlight it here.