### PR TITLE
Fix nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ matrix:
         - cargo bench --features nightly
         - cargo test --features spin_no_std
         - cargo bench --features spin_no_std
+        - cd compiletest
         - cargo clean
-        - cargo test --features compiletest
+        - cargo test
+        - cd ../
 
     - rust: nightly
       before_script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,9 @@ categories = [ "no-std", "rust-patterns", "memory-management" ]
 version = "0.4.6"
 optional = true
 
-[dependencies.compiletest_rs]
-version = "0.3"
-optional = true
-
 [features]
 nightly = []
 spin_no_std = ["nightly", "spin"]
-compiletest = ["compiletest_rs"]
 
 [badges]
 appveyor = { repository = "rust-lang-nursery/lazy-static.rs" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,9 @@ test_script:
   - cargo build --verbose
   - cargo test
   - if [%CHANNEL%]==[nightly] (
+      cd compiletest &&
       cargo clean &&
-      cargo build --verbose --features "compiletest" &&
-      cargo test --features "compiletest"
+      cargo build --verbose &&
+      cargo test &&
+      cd ../
     )

--- a/compiletest/Cargo.toml
+++ b/compiletest/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lazy_static_compiletest"
+version = "0.0.1"
+publish = false
+authors = ["lazy_static contributors"]
+
+[dependencies.lazy_static]
+path = "../"
+
+[dependencies.compiletest_rs]
+version = "0.3"

--- a/compiletest/src/lib.rs
+++ b/compiletest/src/lib.rs
@@ -1,0 +1,13 @@
+/*
+This library is a shim around `lazy_static` that disambiguates it with the `lazy_static`
+that's shipped with the Rust toolchain. We re-export the entire public API of `lazy_static`
+under a different crate name so that can be imported in the compile tests.
+
+This currently appears to use the right local build of `lazy_static`.
+*/
+
+#![feature(use_extern_macros)]
+
+extern crate lazy_static;
+
+pub use self::lazy_static::*;

--- a/compiletest/tests/compile-fail/README.md
+++ b/compiletest/tests/compile-fail/README.md
@@ -3,7 +3,7 @@ warning/note/help/error at compilation. Syntax of annotations is described in
 [rust documentation](https://github.com/rust-lang/rust/blob/master/src/test/COMPILER_TESTS.md).
 For more information check out [`compiletest` crate](https://github.com/laumann/compiletest-rs).
 
-To run compile tests issue `cargo +nightly --test --features compiletest`.
+To run compile tests issue `cargo +nightly --test`.
 
 ## Notes on working with `compiletest` crate
 

--- a/compiletest/tests/compile-fail/incorrect_visibility_restriction.rs
+++ b/compiletest/tests/compile-fail/incorrect_visibility_restriction.rs
@@ -1,6 +1,6 @@
 // incorrect visibility restriction
 #[macro_use]
-extern crate lazy_static;
+extern crate lazy_static_compiletest as lazy_static;
 
 lazy_static! {
     pub(nonsense) static ref WRONG: () = ();

--- a/compiletest/tests/compile-fail/static_is_private.rs
+++ b/compiletest/tests/compile-fail/static_is_private.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate lazy_static;
+extern crate lazy_static_compiletest as lazy_static;
 
 mod outer {
     pub mod inner {

--- a/compiletest/tests/compile-fail/static_is_sized.rs
+++ b/compiletest/tests/compile-fail/static_is_sized.rs
@@ -1,6 +1,6 @@
 // error-pattern:the trait bound `str: std::marker::Sized` is not satisfied
 #[macro_use]
-extern crate lazy_static;
+extern crate lazy_static_compiletest as lazy_static;
 
 lazy_static! {
     pub static ref FOO: str = panic!();

--- a/compiletest/tests/compile-fail/static_never_used.rs
+++ b/compiletest/tests/compile-fail/static_never_used.rs
@@ -1,7 +1,7 @@
 // error-pattern:static item is never used: `UNUSED`
 #![deny(dead_code)]
 #[macro_use]
-extern crate lazy_static;
+extern crate lazy_static_compiletest as lazy_static;
 
 lazy_static! {
     static ref UNUSED: () = ();

--- a/compiletest/tests/compile_tests.rs
+++ b/compiletest/tests/compile_tests.rs
@@ -1,13 +1,14 @@
-#![cfg(feature="compiletest")]
 extern crate compiletest_rs as compiletest;
 
 fn run_mode(mode: &'static str) {
     let mut config = compiletest::Config::default();
     config.mode = mode.parse().expect("Invalid mode");
     config.src_base = ["tests", mode].iter().collect();
-    config.target_rustcflags = Some("-L target/debug/ -L target/debug/deps/".to_owned());
 
     config.verbose = true;
+
+    config.target_rustcflags = Some("-L target/debug/ -L target/debug/deps/".to_owned());
+    config.clean_rmeta();
 
     compiletest::run_tests(&config);
 }

--- a/src/nightly_lazy.rs
+++ b/src/nightly_lazy.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate std;
+extern crate core;
 
 use self::std::prelude::v1::*;
 use self::std::sync::Once;
@@ -27,7 +28,7 @@ impl<T: Sync> Lazy<T> {
         unsafe {
             match self.0 {
                 Some(ref x) => x,
-                None => std::mem::unreachable(),
+                None => core::hint::unreachable_unchecked(),
             }
         }
     }


### PR DESCRIPTION
Based on #97 

I also had a look at our compile fail tests, looks like our `rustc` invocations can't disambiguate between the `lazy_static` that ships with the Rust toolchain and the `lazy_static` we build locally. I've 'fixed' this up by wrapping `lazy_static` in a shim with a different name. It seems to work.

cc @Kimundi @superp00t