### PR TITLE
Update unsized error msg pattern

### DIFF
--- a/compiletest/tests/compile-fail/static_is_sized.rs
+++ b/compiletest/tests/compile-fail/static_is_sized.rs
@@ -1,4 +1,4 @@
-// error-pattern:the trait bound `str: std::marker::Sized` is not satisfied
+// error-pattern:the size for value values of type `str` cannot be known at compilation time
 #[macro_use]
 extern crate lazy_static_compiletest as lazy_static;
 


### PR DESCRIPTION
Looks like the error messages for unsized types have been improved.