### PR TITLE
Use local_inner_macros to resolve all helper macros within $crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub mod lazy;
 #[doc(hidden)]
 pub use core::ops::Deref as __Deref;
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! __lazy_static_internal {
     // optional visibility restrictions are wrapped in `()` to allow for
@@ -170,7 +170,7 @@ macro_rules! __lazy_static_internal {
     () => ()
 }
 
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! lazy_static {
     ($(#[$attr:meta])* static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
         // use `()` to explicitly forward the information about private items


### PR DESCRIPTION
This fixes the following error when using Rust 2018 style macro imports.

```rust
extern crate lazy_static;
use lazy_static::lazy_static;
```

```
error: cannot find macro `__lazy_static_internal!` in this scope
  --> src/main.rs:8:1
   |
8  | / lazy_static! {
9  | |     static ref M: HashMap<String, String> = HashMap::new();
10 | | }
   | |_^
   |
```

The `local_inner_macros` modifier resolves all macro invocations made from within that macro as helpers in the same crate. So if `lazy_static!` expands to an invocation of `__lazy_static_internal!` then this would be resolved as `$crate::__lazy_static_internal!` rather than requiring the caller to have `__lazy_static_internal` in scope.

The attribute is ignored by pre-2018 compilers so lazy_static will continue to work as normal with `#[macro_use]`.

In the future when dropping compatibility with pre-2018 compilers we can remove the `local_inner_macros` modifier and use our own explicit `$crate::` prefixes on invocations of helper macros.