### PR TITLE
Prepare for 1.1.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lazy_static"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "1.0.2"
+version = "1.1.0"
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT/Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the following dependency to your Cargo manifest...
 
 ```toml
 [dependencies]
-lazy_static = "1.0"
+lazy_static = "1.1.0"
 ```
 
 ...and see the [docs](https://docs.rs/lazy_static) for how to use it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ no guarantees can be made about them in regard to SemVer stability.
 // NOTE: see build.rs for where these cfg values are set.
 #![cfg_attr(lazy_static_spin_impl, feature(const_fn))]
 
-#![doc(html_root_url = "https://docs.rs/lazy_static/1.0.2")]
+#![doc(html_root_url = "https://docs.rs/lazy_static/1.1.0")]
 #![no_std]
 
 #[cfg(lazy_static_heap_impl)]


### PR DESCRIPTION
Including #103 which fixes a soundness issue with public fields and introduces a build script to automatically select an appropriate implementation based on the available compiler.

I went for the conservative versioning approach of `1.1.0` instead of `1.0.3` since the implementation of `lazy_static` may change, but if anyone would prefer a patch I'll update it.