### PR TITLE
Switch to version_check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.4.6"
 optional = true
 
 [build-dependencies]
-rustc_version = "0.2.2"
+version_check = "0.1.4"
 
 [features]
 nightly = []

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,4 @@
-extern crate rustc_version;
-
-use rustc_version::{version, Version};
+extern crate version_check;
 
 fn main() {
     let is_var_set = |s| std::env::var_os(s).is_some();
@@ -23,7 +21,7 @@ fn main() {
     let nightly_feature_enabled = is_var_set("CARGO_FEATURE_NIGHTLY");
     let spin_feature_enabled = is_var_set("CARGO_FEATURE_SPIN_NO_STD");
 
-    let version_geq_122 = version().unwrap() >= Version::new(1, 22, 0);
+    let version_geq_122 = version_check::is_min_version("1.22.0").unwrap().0;
     let drop_in_static_supported = version_geq_122 || nightly_feature_enabled;
 
     // precedence:


### PR DESCRIPTION
We shouldn't need to pull in a dependency on a production-quality semver implementation to tell whether \>=1.22.0 is met. The version_check crate is intended for exactly this build script use case and compiles more than twice as fast.