### PR TITLE
using the stable spin's once implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ matrix:
   include:
     - rust: 1.21.0
     - rust: stable
+      script:
+        - cargo test
+        - cargo test --features spin_no_std
     - os: osx
     - rust: beta
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,17 @@ exclude = ["/.travis.yml", "/appveyor.yml"]
 build = "build.rs"
 
 [dependencies.spin]
-version = "0.4.6"
+version = "0.4.10"
 optional = true
+default-features = false
+features = ["once"]
 
 [build-dependencies]
 version_check = "0.1.4"
 
 [features]
 nightly = []
-spin_no_std = ["nightly", "spin"]
+spin_no_std = ["spin"]
 
 [badges]
 appveyor = { repository = "rust-lang-nursery/lazy-static.rs" }

--- a/src/core_lazy.rs
+++ b/src/core_lazy.rs
@@ -12,10 +12,7 @@ use self::spin::Once;
 pub struct Lazy<T: Sync>(Once<T>);
 
 impl<T: Sync> Lazy<T> {
-    #[inline(always)]
-    pub const fn new() -> Self {
-        Lazy(Once::new())
-    }
+    pub const INIT: Self = Lazy(Once::INIT);
 
     #[inline(always)]
     pub fn get<F>(&'static self, builder: F) -> &T
@@ -29,6 +26,6 @@ impl<T: Sync> Lazy<T> {
 #[doc(hidden)]
 macro_rules! __lazy_static_create {
     ($NAME:ident, $T:ty) => {
-        static $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy::new();
+        static $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy::INIT;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,6 @@ no guarantees can be made about them in regard to SemVer stability.
 
 */
 
-// NOTE: see build.rs for where these cfg values are set.
-#![cfg_attr(lazy_static_spin_impl, feature(const_fn))]
-
 #![doc(html_root_url = "https://docs.rs/lazy_static/1.1.0")]
 #![no_std]
 

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -1,5 +1,4 @@
 #![cfg(feature="spin_no_std")]
-#![feature(const_fn)]
 
 #![no_std]
 


### PR DESCRIPTION
I am opening a different pull request since this is different from #122 
We should now be able to have no_std lazy_static with stable Rust.