### PR TITLE
Prepare for 1.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lazy_static"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT/Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ as well as anything that requires non-const function calls to be computed.
 
 ## Minimum supported `rustc`
 
-`1.21.0+`
+`1.24.1+`
 
 This version is explicitly tested in CI and may only be bumped in new minor versions. Any changes to the supported minimum version will be called out in the release notes.
 


### PR DESCRIPTION
[Current changeset](https://github.com/rust-lang-nursery/lazy-static.rs/compare/1.1.0...master)

This release includes a change that bumps our minimum supported rustc version from `1.21.0` to `1.24.1` in order to solve a soundness issue (see #117 for details). This compiler version does seem to be readily available in package managers.

cc @Kimundi @eddyb @RalfJung

also cc @BurntSushi @jethrogb (who might be interested in the minimum version bump)