### PR TITLE
Update examples for 2018 edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ lazy_static = "1.2.0"
 
 # Example
 
-```rust
-#[macro_use]
-extern crate lazy_static;
+Using 2018 Edition:
 
+```rust
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 
 lazy_static! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ lazy_static! {
 Attributes (including doc comments) are supported as well:
 
 ```rust
-# #[macro_use]
-# extern crate lazy_static;
+# use lazy_static::lazy_static;
+#
 # fn main() {
 lazy_static! {
     /// This is an example for using doc comment attributes
@@ -58,9 +58,7 @@ have generally the same properties as regular "static" variables:
 Using the macro:
 
 ```rust
-#[macro_use]
-extern crate lazy_static;
-
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 
 lazy_static! {
@@ -192,8 +190,7 @@ pub trait LazyStatic {
 /// Example:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate lazy_static;
+/// use lazy_static::lazy_static;
 ///
 /// lazy_static! {
 ///     static ref BUFFER: Vec<u8> = (0..65537).collect();


### PR DESCRIPTION
Addresses #120 

Removes `#[macro_use] extern crate lazy_static;` in favor of the simpler `use lazy_static::lazy_static` enabled in 2018 edition.