### PR TITLE
Remove redundant nightly feature, fixes #136

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ default-features = false
 features = ["once"]
 
 [features]
-nightly = []
 spin_no_std = ["spin"]
 
 [badges]


### PR DESCRIPTION
This PR fixes #136, since the nightly feature is now redundant.