### PR TITLE
Remove reference to the nightly feature from crate docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,7 @@ The `Deref` implementation uses a hidden static variable that is guarded by an a
 
 This crate provides two cargo features:
 
-- `nightly`: This uses unstable language features only available on the nightly release channel for a more optimal implementation. In practice this currently means avoiding a heap allocation per static. This feature might get deprecated at a later point once all relevant optimizations are usable from stable.
-- `spin_no_std` (implies `nightly`): This allows using this crate in a no-std environment, by depending on the standalone `spin` crate.
+- `spin_no_std`: This allows using this crate in a no-std environment, by depending on the standalone `spin` crate.
 
 Both features depend on unstable language features, which means
 no guarantees can be made about them in regard to SemVer stability.


### PR DESCRIPTION
Following up for #136 

Just removes a reference to the `nightly` feature (that was removed in #138) from the crate docs.

I thought I'd leave the CI jobs for building and checking on `nightly` just because it's nice to know whether the `nightly` channel manages to break in some way so that can get reported back upstream.

cc @Ericson2314 