### PR TITLE
Prepare for 1.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lazy_static"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT/Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the following dependency to your Cargo manifest...
 
 ```toml
 [dependencies]
-lazy_static = "1.2.0"
+lazy_static = "1.3.0"
 ```
 
 ...and see the [docs](https://docs.rs/lazy_static) for how to use it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ no guarantees can be made about them in regard to SemVer stability.
 
 */
 
-#![doc(html_root_url = "https://docs.rs/lazy_static/1.2.0")]
+#![doc(html_root_url = "https://docs.rs/lazy_static/1.3.0")]
 #![no_std]
 
 #[cfg(not(feature = "spin_no_std"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ pub trait LazyStatic {
 /// extern crate lazy_static;
 ///
 /// lazy_static! {
-///     static ref BUFFER: Vec<u8> = (0..65537).collect();
+///     static ref BUFFER: Vec<u8> = (0..255).collect();
 /// }
 ///
 /// fn main() {


### PR DESCRIPTION
[Changes since the last release](https://github.com/rust-lang-nursery/lazy-static.rs/compare/1.2.0...master)

Includes:

- #139 
- #140 
- #142 

I figured we should bump the minor version since we are removing the now unused unstable `nightly` feature flag.