### PR TITLE
Automatically check if README.md examples are working when running "cargo test"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ optional = true
 [features]
 spin_no_std = ["spin"]
 
+[dev-dependencies]
+doc-comment = "0.3.1"
+
 [badges]
 appveyor = { repository = "rust-lang-nursery/lazy-static.rs" }
 travis-ci = { repository = "rust-lang-nursery/lazy-static.rs" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,13 @@ This crate provides one cargo feature:
 #[doc(hidden)]
 pub mod lazy;
 
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
+
 #[cfg(feature = "spin_no_std")]
 #[path="core_lazy.rs"]
 #[doc(hidden)]


### PR DESCRIPTION
Since rustdoc nightly now provides "cfg(test)" when running on test mode, we can now use this macro on test mode only to check if README.md examples are working as expected.