### PR TITLE
bump MSRV to 1.27.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 matrix:
   include:
-    - rust: 1.24.1
+    - rust: 1.27.2
     - rust: stable
       script:
         - cargo test

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ as well as anything that requires non-const function calls to be computed.
 
 ## Minimum supported `rustc`
 
-`1.24.1+`
+`1.27.2+`
 
 This version is explicitly tested in CI and may only be bumped in new minor versions. Any changes to the supported minimum version will be called out in the release notes.
 

--- a/src/inline_lazy.rs
+++ b/src/inline_lazy.rs
@@ -15,7 +15,7 @@ use self::std::sync::Once;
 #[allow(deprecated)]
 pub use self::std::sync::ONCE_INIT;
 
-// FIXME: Replace Option<T> with MaybeInitialized<T>
+// FIXME: Replace Option<T> with MaybeUninit<T> (stable since 1.36.0)
 pub struct Lazy<T: Sync>(Cell<Option<T>>, Once);
 
 impl<T: Sync> Lazy<T> {

--- a/src/inline_lazy.rs
+++ b/src/inline_lazy.rs
@@ -10,6 +10,7 @@ extern crate std;
 
 use self::std::prelude::v1::*;
 use self::std::cell::Cell;
+use self::std::hint::unreachable_unchecked;
 use self::std::sync::Once;
 #[allow(deprecated)]
 pub use self::std::sync::ONCE_INIT;
@@ -53,16 +54,4 @@ macro_rules! __lazy_static_create {
     ($NAME:ident, $T:ty) => {
         static $NAME: $crate::lazy::Lazy<$T> = $crate::lazy::Lazy::INIT;
     };
-}
-
-/// Polyfill for std::hint::unreachable_unchecked. There currently exists a
-/// [crate](https://docs.rs/unreachable) for an equivalent to std::hint::unreachable_unchecked, but
-/// lazy_static currently doesn't include any runtime dependencies and we've chosen to include this
-/// short polyfill rather than include a new crate in every consumer's build.
-///
-/// This should be replaced by std's version when lazy_static starts to require at least Rust 1.27.
-unsafe fn unreachable_unchecked() -> ! {
-    enum Void {}
-    #[allow(deprecated)]
-    match std::mem::uninitialized::<Void>() {}
 }

--- a/src/inline_lazy.rs
+++ b/src/inline_lazy.rs
@@ -32,7 +32,7 @@ impl<T: Sync> Lazy<T> {
         });
 
         // `self.0` is guaranteed to be `Some` by this point
-        // The `Once` will catch and propegate panics
+        // The `Once` will catch and propagate panics
         unsafe {
             match *self.0.as_ptr() {
                 Some(ref x) => x,


### PR DESCRIPTION
closes #154

I think it's worth bumping MSRV to get rid of `uninitialized::<Void>`.