### PR TITLE
Prepare for 1.4.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lazy_static"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT/Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the following dependency to your Cargo manifest...
 
 ```toml
 [dependencies]
-lazy_static = "1.3.0"
+lazy_static = "1.4.0"
 ```
 
 ...and see the [docs](https://docs.rs/lazy_static) for how to use it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ This crate provides one cargo feature:
 
 */
 
-#![doc(html_root_url = "https://docs.rs/lazy_static/1.3.0")]
+#![doc(html_root_url = "https://docs.rs/lazy_static/1.4.0")]
 #![no_std]
 
 #[cfg(not(feature = "spin_no_std"))]


### PR DESCRIPTION
[Changes since the last release](https://github.com/rust-lang-nursery/lazy-static.rs/compare/1.3.0...master)

Includes:

- #144
- #145
- #152
- #155

This release will bump our minimum Rust version to `1.27`.