### PR TITLE
Update examples for 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: rust
 matrix:
   include:
     - rust: 1.27.2
+      script:
+        - cargo test --all-targets
     - rust: stable
       script:
         - cargo test

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ lazy_static = "1.4.0"
 # Example
 
 ```rust
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 
 lazy_static! {

--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ lazy_static = "1.4.0"
 # Example
 
 ```rust
-#[macro_use]
-extern crate lazy_static;
-
 use std::collections::HashMap;
 
 lazy_static! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ lazy_static! {
 Attributes (including doc comments) are supported as well:
 
 ```rust
-# #[macro_use]
-# extern crate lazy_static;
+use lazy_static::lazy_static;
+
 # fn main() {
 lazy_static! {
     /// This is an example for using doc comment attributes
@@ -58,9 +58,7 @@ have generally the same properties as regular "static" variables:
 Using the macro:
 
 ```rust
-#[macro_use]
-extern crate lazy_static;
-
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 
 lazy_static! {
@@ -195,8 +193,7 @@ pub trait LazyStatic {
 /// Example:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate lazy_static;
+/// use lazy_static::lazy_static;
 ///
 /// lazy_static! {
 ///     static ref BUFFER: Vec<u8> = (0..255).collect();


### PR DESCRIPTION
Don't run 1.27.2 doc examples (based off #134)