### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main() {
     let force_spin_cfg = is_var_set("CARGO_CFG_LAZY_STATIC_SPIN_IMPL");
 
     let impls_forced = [force_heap_cfg, force_inline_cfg, force_spin_cfg]
-        .into_iter()
+        .iter()
         .filter(|&&f| f)
         .count();
 


### PR DESCRIPTION
`lazy_static` 1.1.0 is already quite old, but for some reason some creates have a `~1.1.0` version requirement. As a consequence, quite a few crates still have `lazy_static` 1.1.0 in their dependency tree. That particular version regresses with https://github.com/rust-lang/rust/pull/65819, as `array.into_iter()` is used in the build script. [This report says](https://gist.github.com/LukasKalbertodt/a4ad46ca391dcc134c349100880c884c) that `lazy_static` 1.1.0 causes roughly 800 other crates to regress. 

Ideally all crates would upgrade to a newer `lazy_static`, but that might now happen. Therefore my idea: release `1.1.1` with this tiny change. It does not require a newer Rust compiler version and fixes a bunch of crates. What do you think?

(PS: the PR targeting `master` is obviously wrong. I just wanted to create this PR for some discussion about this. If everyone agrees we should release `1.1.1`, I can manually "merge" this into the main repo)