### PR TITLE
Add function `reset`

### DIFF
--- a/src/inline_lazy.rs
+++ b/src/inline_lazy.rs
@@ -11,37 +11,102 @@ extern crate std;
 use self::std::prelude::v1::*;
 use self::std::cell::Cell;
 use self::std::hint::unreachable_unchecked;
+use self::std::ptr::null;
+use self::std::sync::atomic::AtomicPtr;
+use self::std::sync::atomic::Ordering::SeqCst;
 use self::std::sync::Once;
 #[allow(deprecated)]
 pub use self::std::sync::ONCE_INIT;
 
+macro_rules! uninitialized {
+    ( $x:expr ) => {{
+        debug_assert!(
+            false,
+            concat!(
+                "attempted to ",
+                $x,
+                " an uninitialized lazy static. This is a bug"
+            )
+        );
+        unreachable_unchecked()
+    }};
+}
+
+trait Resettable {
+    fn reset(&self);
+}
+
+struct Node(*const Node, &'static dyn Resettable);
+
 // FIXME: Replace Option<T> with MaybeUninit<T> (stable since 1.36.0)
-pub struct Lazy<T: Sync>(Cell<Option<T>>, Once);
+pub struct Lazy<T: Sync>(Cell<Option<T>>, Cell<Once>);
+
+static INITED: AtomicPtr<Node> = AtomicPtr::new(null::<Node>() as *mut Node);
+
+/// Puts all initialized `lazy_static` variables back in their
+/// uninitialized states. The caller is responsible for ensuring that
+/// there are no outstanding references to those variables. Similarly,
+/// the caller must not try to initialize a `lazy_static` variable
+/// concurrently with a call to `reset`, as this presents a data race.
+pub unsafe fn reset() {
+    let mut node_ptr = INITED.swap(null::<Node>() as *mut Node, SeqCst) as *const Node;
+    while node_ptr != null() {
+        let node_box = Box::from_raw(node_ptr as *mut Node);
+        node_ptr = (*node_box).0;
+        (*node_box).1.reset();
+    }
+}
+
+#[inline(always)]
+unsafe fn lysis<T>(cell: &Cell<T>) -> &T {
+    &*cell.as_ptr()
+}
 
 impl<T: Sync> Lazy<T> {
     #[allow(deprecated)]
-    pub const INIT: Self = Lazy(Cell::new(None), ONCE_INIT);
+    pub const INIT: Self = Lazy(Cell::new(None), Cell::new(ONCE_INIT));
 
     #[inline(always)]
     pub fn get<F>(&'static self, f: F) -> &T
     where
         F: FnOnce() -> T,
     {
-        self.1.call_once(|| {
+        unsafe { lysis(&self.1) }.call_once(|| {
             self.0.set(Some(f()));
+            let node_box = Box::new(Node(INITED.load(SeqCst), self));
+            let node_ptr = Box::into_raw(node_box);
+            loop {
+                let prev_ptr = INITED.compare_and_swap(
+                    unsafe { (*node_ptr).0 } as *mut Node,
+                    node_ptr,
+                    SeqCst,
+                ) as *const Node;
+                if prev_ptr == unsafe { (*node_ptr).0 } {
+                    break;
+                }
+                unsafe {
+                    (*node_ptr).0 = prev_ptr;
+                }
+            }
         });
 
         // `self.0` is guaranteed to be `Some` by this point
         // The `Once` will catch and propagate panics
-        unsafe {
-            match *self.0.as_ptr() {
-                Some(ref x) => x,
-                None => {
-                    debug_assert!(false, "attempted to derefence an uninitialized lazy static. This is a bug");
+        match *unsafe { lysis(&self.0) } {
+            Some(ref x) => x,
+            None => unsafe { uninitialized!("dereference") },
+        }
+    }
+}
 
-                    unreachable_unchecked()
-                },
+impl<T: Sync> Resettable for Lazy<T> {
+    fn reset(&self) {
+        match *unsafe { lysis(&self.0) } {
+            Some(_) => {
+                self.0.set(None);
+                self.1.set(ONCE_INIT);
             }
+            None => unsafe { uninitialized!("reset") },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,10 @@ This crate provides one cargo feature:
 #![no_std]
 
 #[cfg(not(feature = "spin_no_std"))]
+#[macro_use]
+extern crate std;
+
+#[cfg(not(feature = "spin_no_std"))]
 #[path="inline_lazy.rs"]
 #[doc(hidden)]
 pub mod lazy;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -162,3 +162,21 @@ lazy_static! {
 fn lifetime_name() {
     let _ = LIFETIME_NAME;
 }
+
+lazy_static! {
+    static ref RESETTABLE_FLAG: AtomicBool = AtomicBool::new(false);
+}
+
+#[cfg(not(feature = "spin_no_std"))]
+#[test]
+fn reset() {
+    assert_eq!((*RESETTABLE_FLAG).load(SeqCst), false);
+
+    (*RESETTABLE_FLAG).store(true, SeqCst);
+    assert_eq!((*RESETTABLE_FLAG).load(SeqCst), true);
+
+    unsafe {
+        lazy_static::lazy::reset();
+    }
+    assert_eq!((*RESETTABLE_FLAG).load(SeqCst), false);
+}


### PR DESCRIPTION
This PR adds a function `reset` that puts all `lazy_static` variables back in their original, uninitialized states.  Such a function facilitates fuzzing with [AFL](http://lcamtuf.coredump.cx/afl/) in persistent mode.

In persistent mode, AFL does not launch a new process for each fuzzing run.  Rather, the [process loops](https://github.com/rust-fuzz/afl.rs/blob/4e2b8a79a89df9adc9722c954ebc5c9529dfebef/src/lib.rs#L153-L175), repeatedly executing the function under test with new fuzzing inputs.  This can cause problems for programs that use `lazy_static` variables in at least two ways:

1. AFL can give incorrectly low stability reports.  Roughly speaking, stability is the fraction of instructions that are executed the same number of times across different runs of the program with the same input.  Because a `lazy_static` variable's initializer is executed only on the variable's first use, the initializer's instructions are counted against stability, causing it to be low.

2. AFL can fail to report timeouts.  Suppose that a fuzzing input X causes a program to use a large number of `lazy_static` variables, each of which has an expensive initializer.  If each of those variables was used for an earlier fuzzing input, then those variables' intializers will not be run on input X, causing the program to take less time than it otherwise would on input X.

Returning each `lazy_static` variable to its uninitialized state at the end of each fuzzing iteration addresses these problems.  This causes each `lazy_static` variable's initializer to be executed for each fuzzing input that uses that variable.  Thus, the initializer's instructions are not counted against stability.  On the other hand, the time taken to execute the initializer is counted against each input that uses that variable.

Conceptually, this PR does two things:

* It collects all initialized `lazy_static` variables in a linked list.

* It wraps each `lazy_static` variable's `Once` instance in a `Cell`.

The function `reset` walks the linked list in order to set the initialized `lazy_static` variables back to their uninitialized states, assigning `ONCE_INIT` to each `Cell<Once>` in the process.

A program demonstrating the problems described above can be found [here](https://github.com/smoelius/fuzz-lazy-static).  The program further demonstrates that adding a call to `reset` at the end of each fuzzing iteration addresses these problems.