### PR TITLE
Remove unmaintained spin crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ keywords = ["macro", "lazy", "static"]
 categories = [ "no-std", "rust-patterns", "memory-management" ]
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
-[dependencies.spin]
-version = "0.5.0"
+[dependencies.spinning]
+version = "0.0.3"
 optional = true
 
 [features]
-spin_no_std = ["spin"]
+spin_no_std = ["spinning"]
 
 [dev-dependencies]
 doc-comment = "0.3.1"

--- a/src/core_lazy.rs
+++ b/src/core_lazy.rs
@@ -5,9 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate spin;
+extern crate spinning;
 
-use self::spin::Once;
+use self::spinning::Once;
 
 pub struct Lazy<T: Sync>(Once<T>);
 

--- a/src/core_lazy.rs
+++ b/src/core_lazy.rs
@@ -12,7 +12,7 @@ use self::spinning::Once;
 pub struct Lazy<T: Sync>(Once<T>);
 
 impl<T: Sync> Lazy<T> {
-    pub const INIT: Self = Lazy(Once::INIT);
+    pub const INIT: Self = Lazy(Once::new());
 
     #[inline(always)]
     pub fn get<F>(&'static self, builder: F) -> &T

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ The `Deref` implementation uses a hidden static variable that is guarded by an a
 
 This crate provides one cargo feature:
 
-- `spin_no_std`: This allows using this crate in a no-std environment, by depending on the standalone `spin` crate.
+- `spin_no_std`: This allows using this crate in a no-std environment, by depending on the standalone `spinning` crate.
 
 */
 


### PR DESCRIPTION
Close #163.

I chose `spinning-rs` as a replacement for `spin` as it is actively maintained and requires few changes to the code base.

Another alternative is `spinning_top` from `rust_osdev`, however this doesn't implement `Once<T>`.