### PR TITLE
test: VAR; remove unused braces

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -105,7 +105,7 @@ fn test_visibility() {
 
 // This should not cause a warning about a missing Copy implementation
 lazy_static! {
-    pub static ref VAR: i32 = { 0 };
+    pub static ref VAR: i32 = 0;
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]


### PR DESCRIPTION
@Kimundi small fix removed unused braces

```
warning: unnecessary braces around block return value
   --> tests/test.rs:108:31
    |
108 |     pub static ref VAR: i32 = { 0 };
    |                               ^^^^^ help: remove these braces
    |
    = note: `#[warn(unused_braces)]` on by default
```