### PR TITLE
Upgraded spin to 0.7 for better performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = [ "no-std", "rust-patterns", "memory-management" ]
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
 [dependencies.spin]
-version = "0.5.0"
+version = "0.7.0"
 optional = true
 
 [features]


### PR DESCRIPTION
`spin` 0.7 includes performance improvements such as less strict ordering requirements and better spinning. All in all, this should reduce power consumption and improve performance, particularly on platforms like ARM.