### PR TITLE
Properly bump spin to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ categories = [ "no-std", "rust-patterns", "memory-management" ]
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
 [dependencies.spin]
-version = "0.7.0"
+version = "0.9"
 optional = true
+default-features = false
+features = ["once"]
 
 [features]
 spin_no_std = ["spin"]


### PR DESCRIPTION
This PR bumps the `spin` crate to the latest version. `spin` depends on std by default (the `std` feature) so `default-features=false` is required. You don't need anything except `Once` from that crate anyway.

Unfortunately, MSRV needs to be bumped to 1.49, but only when the `spin_no_std` feature is enabled - normal `std` usage will continue work on old compilers as it has been. This bump is necessary since the spin crate requires 1.49 because of `core::hint::spin_loop`.

Pinging @KodrAus as the last person with write access noticed.