### PR TITLE
Replace `Option<T>` with `MaybeUninit<T>`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 matrix:
   include:
-    - rust: 1.27.2
+    - rust: 1.36.0
       script:
         - cargo test --tests
     - rust: stable

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ as well as anything that requires non-const function calls to be computed.
 
 ## Minimum supported `rustc`
 
-`1.27.2+`
+`1.36.0+`
 
 This version is explicitly tested in CI and may only be bumped in new minor versions. Any changes to the supported minimum version will be called out in the release notes.
 

--- a/src/inline_lazy.rs
+++ b/src/inline_lazy.rs
@@ -9,18 +9,17 @@ extern crate core;
 extern crate std;
 
 use self::std::cell::Cell;
-use self::std::hint::unreachable_unchecked;
+use self::std::mem::MaybeUninit;
 use self::std::prelude::v1::*;
 use self::std::sync::Once;
 #[allow(deprecated)]
 pub use self::std::sync::ONCE_INIT;
 
-// FIXME: Replace Option<T> with MaybeUninit<T> (stable since 1.36.0)
-pub struct Lazy<T: Sync>(Cell<Option<T>>, Once);
+pub struct Lazy<T: Sync>(Cell<MaybeUninit<T>>, Once);
 
 impl<T: Sync> Lazy<T> {
     #[allow(deprecated)]
-    pub const INIT: Self = Lazy(Cell::new(None), ONCE_INIT);
+    pub const INIT: Self = Lazy(Cell::new(MaybeUninit::uninit()), ONCE_INIT);
 
     #[inline(always)]
     pub fn get<F>(&'static self, f: F) -> &T
@@ -28,24 +27,12 @@ impl<T: Sync> Lazy<T> {
         F: FnOnce() -> T,
     {
         self.1.call_once(|| {
-            self.0.set(Some(f()));
+            self.0.set(MaybeUninit::new(f()));
         });
 
-        // `self.0` is guaranteed to be `Some` by this point
+        // `self.0` is guaranteed to be initialized by this point
         // The `Once` will catch and propagate panics
-        unsafe {
-            match *self.0.as_ptr() {
-                Some(ref x) => x,
-                None => {
-                    debug_assert!(
-                        false,
-                        "attempted to dereference an uninitialized lazy static. This is a bug"
-                    );
-
-                    unreachable_unchecked()
-                }
-            }
-        }
+        unsafe { &*(*self.0.as_ptr()).as_ptr() }
     }
 }
 


### PR DESCRIPTION
This avoids unneeded tag in `Option` and addresses FIXME comment.