### PR TITLE
Updated spin to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ categories = [ "no-std", "rust-patterns", "memory-management" ]
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
 [dependencies.spin]
-version = "0.7.0"
+version = "0.9"
+default-features = false
+features = ["once"]
 optional = true
 
 [features]


### PR DESCRIPTION
I've removed the minor version number because `spin` strictly follows semver. This should make any `0.9.X` compatible with `lazy-static`'s use of the crate.

Additionally, I've disabled all but the required feature, reducing the amount of unnecessary type-checking that needs to occur and improving compilation performance for users.