### PR TITLE
Apply non-upper-case-globals to generated statics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ macro_rules! __lazy_static_internal {
         $(#[$attr])*
         $($vis)* struct $N {__private_field: ()}
         #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
         $($vis)* static $N: $N = $N {__private_field: ()};
     };
     () => ()

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 #[macro_use]
 extern crate lazy_static;
 use std::collections::HashMap;
@@ -33,6 +35,11 @@ lazy_static! {
 }
 lazy_static! {
     static ref S3: String = [*S1, *S2].join("");
+}
+
+lazy_static! {
+    #[allow(non_upper_case_globals)]
+    pub static ref string: String = "hello".to_string();
 }
 
 #[test]


### PR DESCRIPTION
Closes #153

This is a bit of a bandaid fix that just unconditionally applies `#[allow(non_upper_case_globals)]` on the generated global in the same way we do for non-camel-case type names. With some refactoring to expand to a `const _: () {}` block we could probably make the way attributes are applied to the expanded code consistent but since we're in life-support mode I've just opted for the simplest approach.