### PR TITLE
Update spin to 0.9.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = [ "no-std", "rust-patterns", "memory-management" ]
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
 [dependencies.spin]
-version = "0.9.2"
+version = "0.9.3"
 default-features = false
 features = ["once"]
 optional = true


### PR DESCRIPTION
Already released and fixed a bug for `Once`.

Should be great before lazy-static get officially updated to **1.5.0**.