### PR TITLE
Fix MSRV in readme and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 matrix:
   include:
-    - rust: 1.36.0
+    - rust: 1.40.0
       script:
         - cargo test --tests
     - rust: stable

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ as well as anything that requires non-const function calls to be computed.
 
 ## Minimum supported `rustc`
 
-`1.36.0+`
+`1.40.0+`
 
 This version is explicitly tested in CI and may only be bumped in new minor versions. Any changes to the supported minimum version will be called out in the release notes.
 


### PR DESCRIPTION
As said in https://github.com/rust-lang-nursery/lazy-static.rs/pull/186#issuecomment-838856179, the actual MSRV of lazy_static 1.5.0 is 1.40.