### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the following dependency to your Cargo manifest...
 
 ```toml
 [dependencies]
-lazy_static = "1.5.0"
+lazy_static = "1.4.0"
 ```
 
 ...and see the [docs](https://docs.rs/lazy_static) for how to use it.


### PR DESCRIPTION
Hi, I was adding the package to the dependencies but it gave me an error that version 1.5.0 doesn't exist, and I saw that the latest version was 1.4.0.

fixing typo in dependecies from "1.5.0" to "1.4.0"