### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = [ "no-std", "rust-patterns", "memory-management" ]
 exclude = ["/.travis.yml", "/appveyor.yml"]
 
 [dependencies.spin]
-version = "0.9.3"
+version = "0.9.8"
 default-features = false
 features = ["once"]
 optional = true


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)